### PR TITLE
Create index/delete in triplestore actions for taxonomy terms and media

### DIFF
--- a/config/install/system.action.delete_media_in_triplestore_advancedqueue.yml
+++ b/config/install/system.action.delete_media_in_triplestore_advancedqueue.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - triplestore_indexer
+id: delete_media_in_triplestore_advancedqueue
+label: 'Delete media in Triplestore (via Advanced Queue)'
+type: media
+plugin: delete_media_in_triplestore_advancedqueue

--- a/config/install/system.action.delete_taxonomy_term_in_triplestore_advancedqueue.yml
+++ b/config/install/system.action.delete_taxonomy_term_in_triplestore_advancedqueue.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - triplestore_indexer
+id: delete_taxonomy_term_in_triplestore_advancedqueue
+label: 'Delete taxonomy term in Triplestore (via Advanced Queue)'
+type: taxonomy_term
+plugin: delete_taxonomy_term_in_triplestore_advancedqueue

--- a/config/install/system.action.index_media_to_triplestore_advancedqueue.yml
+++ b/config/install/system.action.index_media_to_triplestore_advancedqueue.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - triplestore_indexer
+id: index_media_to_triplestore_advancedqueue
+label: 'Index media to Triplestore (via Advanced Queue)'
+type: media
+plugin: index_media_to_triplestore_advancedqueue

--- a/config/install/system.action.index_taxonomy_term_to_triplestore_advancedqueue.yml
+++ b/config/install/system.action.index_taxonomy_term_to_triplestore_advancedqueue.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - triplestore_indexer
+id: index_taxonomy_term_to_triplestore_advancedqueue
+label: 'Index taxonomy term to Triplestore (via Advanced Queue)'
+type: taxonomy_term
+plugin: index_taxonomy_term_to_triplestore_advancedqueue

--- a/src/Plugin/Action/DeleteMediaInTriplestore.php
+++ b/src/Plugin/Action/DeleteMediaInTriplestore.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\triplestore_indexer\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Provides a Delete media in Triplestore action.
+ *
+ * @Action(
+ *   id = "delete_media_in_triplestore_advancedqueue",
+ *   label = @Translation("Delete media in Triplestore [via Advanced Queue]"),
+ *   type = "media",
+ *   category = @Translation("Custom")
+ * )
+ *
+ * @DCG
+ * For a simple updating entity fields consider extending FieldUpdateActionBase.
+ */
+class DeleteMediaInTriplestore extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($media, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\media\MediaInterface $media */
+    $access = $media->access('delete', $account, TRUE)
+      ->andIf($media->name->access('edit', $account, TRUE));
+    return $return_as_object ? $access : $access->isAllowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($media = NULL) {
+    /** @var \Drupal\media\MediaInterface $media */
+    queue_process($media, 'delete');
+  }
+
+}

--- a/src/Plugin/Action/DeleteTaxonomyTermInTriplestore.php
+++ b/src/Plugin/Action/DeleteTaxonomyTermInTriplestore.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\triplestore_indexer\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Provides a Delete taxonomy term in Triplestore action.
+ *
+ * @Action(
+ *   id = "delete_taxonomy_term_in_triplestore_advancedqueue",
+ *   label = @Translation("Delete taxonomy term in Triplestore [via Advanced Queue]"),
+ *   type = "taxonomy_term",
+ *   category = @Translation("Custom")
+ * )
+ *
+ * @DCG
+ * For a simple updating entity fields consider extending FieldUpdateActionBase.
+ */
+class DeleteTaxonomyTermInTriplestore extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($term, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    $access = $term->access('delete', $account, TRUE)
+      ->andIf($term->name->access('edit', $account, TRUE));
+    return $return_as_object ? $access : $access->isAllowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($term = NULL) {
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    queue_process($term, 'delete');
+  }
+
+}

--- a/src/Plugin/Action/IndexMediaToTriplestore.php
+++ b/src/Plugin/Action/IndexMediaToTriplestore.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\triplestore_indexer\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Provides an Index media to Triplestore action.
+ *
+ * @Action(
+ *   id = "index_media_to_triplestore_advancedqueue",
+ *   label = @Translation("Index media to Triplestore [via Advanced Queue]"),
+ *   type = "media",
+ *   category = @Translation("Custom")
+ * )
+ *
+ * @DCG
+ * For a simple updating entity fields consider extending FieldUpdateActionBase.
+ */
+class IndexMediaToTriplestore extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($media, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\media\MediaInterface $media */
+    $access = $media->access('update', $account, TRUE)
+      ->andIf($media->name->access('edit', $account, TRUE));
+    return $return_as_object ? $access : $access->isAllowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($media = NULL) {
+    // Index the latest version of the media.
+    /** @var \Drupal\media\MediaInterface $media */
+    queue_process($media, 'insert');
+  }
+
+}

--- a/src/Plugin/Action/IndexTaxonomyTermToTriplestore.php
+++ b/src/Plugin/Action/IndexTaxonomyTermToTriplestore.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\triplestore_indexer\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Provides an Index taxonomy term to Triplestore action.
+ *
+ * @Action(
+ *   id = "index_taxonomy_term_to_triplestore_advancedqueue",
+ *   label = @Translation("Index taxonomy term to Triplestore [via Advanced Queue]"),
+ *   type = "taxonomy_term",
+ *   category = @Translation("Custom")
+ * )
+ *
+ * @DCG
+ * For a simple updating entity fields consider extending FieldUpdateActionBase.
+ */
+class IndexTaxonomyTermToTriplestore extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($term, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    $access = $term->access('update', $account, TRUE)
+      ->andIf($term->name->access('edit', $account, TRUE));
+    return $return_as_object ? $access : $access->isAllowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($term = NULL) {
+    // Index the latest version of the term.
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    queue_process($term, 'insert');
+  }
+
+}

--- a/triplestore_indexer.module
+++ b/triplestore_indexer.module
@@ -65,6 +65,48 @@ function triplestore_indexer_entity_predelete(EntityInterface $entity) {
 }
 
 /**
+ * Implements hook_taxonomy_term_insert().
+ */
+function triplestore_indexer_taxonomy_term_insert(EntityInterface $term) {
+  drupal_register_shutdown_function('execute_indexing_action', 'index_taxonomy_term_to_triplestore_advancedqueue', $term);
+}
+
+/**
+ * Implements hook_taxonomy_term_update().
+ */
+function triplestore_indexer_taxonomy_term_update(EntityInterface $term) {
+  drupal_register_shutdown_function('execute_indexing_action', 'index_taxonomy_term_to_triplestore_advancedqueue', $term);
+}
+
+/**
+ * Implements hook_taxonomy_term_delete().
+ */
+function triplestore_indexer_taxonomy_term_predelete(EntityInterface $term) {
+  execute_indexing_action('delete_taxonomy_term_in_triplestore_advancedqueue', $term);
+}
+
+/**
+ * Implements hook_media_insert().
+ */
+function triplestore_indexer_media_insert(EntityInterface $media) {
+  drupal_register_shutdown_function('execute_indexing_action', 'index_media_to_triplestore_advancedqueue', $media);
+}
+
+/**
+ * Implements hook_media_update().
+ */
+function triplestore_indexer_media_update(EntityInterface $media) {
+  drupal_register_shutdown_function('execute_indexing_action', 'index_media_to_triplestore_advancedqueue', $media);
+}
+
+/**
+ * Implements hook_media_delete().
+ */
+function triplestore_indexer_media_predelete(EntityInterface $media) {
+  execute_indexing_action('delete_media_in_triplestore_advancedqueue', $media);
+}
+
+/**
  * Execute action with action name.
  */
 function execute_indexing_action(string $actionName, EntityInterface $entity) {
@@ -176,8 +218,7 @@ function queue_process(EntityInterface $entity, $action) {
   switch ($action) {
     case 'insert':
     case 'update':
-      if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $indexedContentTypes)) {
-
+      if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $indexedContentTypes) || $entity->getEntityTypeId() === 'taxonomy_term' || $entity->getEntityTypeId() === 'media') {
         // Create a job and add to Advanced Queue.
         $payload = [
           'nid' => $entity->id(),
@@ -186,13 +227,6 @@ function queue_process(EntityInterface $entity, $action) {
           'max_tries' => $config->get("aqj_max_retries"),
           'retry_delay' => $config->get("aqj_retry_delay"),
         ];
-
-        // Create a job and add to Advanced Queue.
-        $job = Job::create('triplestore_index_job', $payload);
-        if ($job instanceof Job) {
-          $q = Queue::load($config->get("advancedqueue_id"));
-          $q->enqueueJob($job);
-        }
       }
       break;
 
@@ -209,22 +243,48 @@ function queue_process(EntityInterface $entity, $action) {
         ];
         $service = \Drupal::service('triplestore_indexer.indexing');
         $others = $service->getOtherConmponentAssocNode($payload);
-
-        // Create a job and add to Advanced Queue.
         if (is_array($others) && count($others) > 0) {
           $payload['others'] = $others;
         }
-
-        $job = Job::create('triplestore_index_job', $payload);
-        if ($job instanceof Job) {
-          $q = Queue::load($config->get("advancedqueue_id"));
-          $q->enqueueJob($job);
+      }
+      else if ($entity->getEntityTypeId() === 'taxonomy_term') {
+        // Get @id of other components associated with term.
+        $payload = [
+          'nid' => $entity->id(),
+          'type' => $entity->getEntityTypeId(),
+          'action' => $action,
+          'max_tries' => $config->get("aqj_max_retries"),
+          'retry_delay' => $config->get("aqj_retry_delay"),
+        ];
+        $service = \Drupal::service('triplestore_indexer.indexing');
+        $others = $service->getOtherComponentAssocTaxonomyTerm($payload);
+        if (is_array($others) && count($others) > 0) {
+          $payload['others'] = $others;
         }
+      }
+      else if ($entity->getEntityTypeId() === 'media') {
+        // Create a job and add to Advanced Queue.
+        $payload = [
+          'nid' => $entity->id(),
+          'type' => $entity->getEntityTypeId(),
+          'action' => $action,
+          'max_tries' => $config->get("aqj_max_retries"),
+          'retry_delay' => $config->get("aqj_retry_delay"),
+        ];
       }
       break;
 
     default:
       break;
+  }
+
+  if (is_array($payload) && count($payload) > 0) {
+    // Create a job and add to Advanced Queue.
+    $job = Job::create('triplestore_index_job', $payload);
+    if ($job instanceof Job) {
+      $q = Queue::load($config->get("advancedqueue_id"));
+      $q->enqueueJob($job);
+    }
   }
 }
 

--- a/triplestore_indexer.module
+++ b/triplestore_indexer.module
@@ -278,7 +278,7 @@ function queue_process(EntityInterface $entity, $action) {
       break;
   }
 
-  if (is_array($payload) && count($payload) > 0) {
+  if (isset($payload) && is_array($payload) && count($payload) > 0) {
     // Create a job and add to Advanced Queue.
     $job = Job::create('triplestore_index_job', $payload);
     if ($job instanceof Job) {


### PR DESCRIPTION
Summary of Changes:
- New actions for indexing/deleting taxonomy terms and media in Triplestore
- Taxonomy terms and media are automatically indexed when created/updated and removed from Blazegraph when deleted