### PR TITLE
Integrated Context Reaction with Triplestore Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ This Drupal 8 or 9's module provide a system to get the Json-LD representation (
   - **Method of operation**:
     + **[Drupal Entity Hooks](https://api.drupal.org/api/drupal/core%21core.api.php/group/hooks/9.0.x)**: By default this option selected, the indexing will be executed immediately after a node or a taxonomy term is [created](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21entity.api.php/function/hook_entity_insert/9.0.x), [update](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21entity.api.php/function/hook_entity_update/9.0.x), or [deleted](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21entity.api.php/function/hook_entity_delete/9.0.x). (*WARNING: it may effect the performance of the site if many nodes/taxonomy terms are being ingested in bulk.*)
     + **[Advanced Queue](https://www.drupal.org/project/advancedqueue)**: Highly Recommended, when a node or a taxonomy term is created, updated, or deleted, the indexing operation will be added to a queue which can be configured to run with Cron job or Drupal Console commnad (eg. drupal advancedqueue:queue:process default). You can create a seperated queue if needed, then enter the new queue's machine name with default in the "Queue" text field below.
-  - **When to index**: During ONLY selected event(s), the indexing will be executed.
-  - **Content type**: For ONLY selected content type(s), the indexing will be executed.
-  - **Taxonomy**: For ONLY selected taxonomy term(s), the indexing will be executed.
+# Enabling Indexing/Deleting
+- To enable indexing/deleting of media, node, or taxonomy term, you must make use of the Context module
+  - Go to `Structure > Context`
+    - Create a Context and choose the Conditions that should be true for the indexing/deleting action to proceed
+    - Under `Reaction` add a Reaction and pick `Triplestore Index Reaction` or `Triplestore Delete Reaction`
+    - In the Action form that shows up for the Reaction, just pick the corresponding one that you would like
+    - Ensure the context is enabled and then save

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "require": {
         "islandora/jsonld": "^3.0",
         "drupal/advancedqueue": "^1.0@RC",
-        "drupal/restui": "^1.21"
+        "drupal/restui": "^1.21",
+        "drupal/context":"^5.0@RC"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",

--- a/config/install/context.context.index_content_blazegraph.yml
+++ b/config/install/context.context.index_content_blazegraph.yml
@@ -18,7 +18,8 @@ conditions:
     context_mapping:
       node: '@node.node_route_context:node'
     bundles:
-      islandora_object: islandora_object
+      article: article
+      page: page
 reactions:
   triplestore_index_reaction:
     id: triplestore_index_reaction

--- a/config/install/context.context.index_content_blazegraph.yml
+++ b/config/install/context.context.index_content_blazegraph.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - triplestore_indexer
+label: Content
+name: index_content_blazegraph
+group: Indexing
+description: 'Index all content to Blazegraph.'
+requireAllConditions: false
+disabled: false
+conditions:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 03fb40c9-96a7-4142-9296-d72806c4c449
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      islandora_object: islandora_object
+reactions:
+  triplestore_index_reaction:
+    id: triplestore_index_reaction
+    actions: index_node_to_triplestore_advancedqueue
+    saved: false
+weight: 0

--- a/config/install/context.context.index_content_blazegraph.yml
+++ b/config/install/context.context.index_content_blazegraph.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - node
     - triplestore_indexer
 label: Content
 name: index_content_blazegraph
@@ -10,14 +9,7 @@ group: Indexing
 description: 'Index all content to Blazegraph.'
 requireAllConditions: false
 disabled: false
-conditions:
-  'entity_bundle:node':
-    id: 'entity_bundle:node'
-    negate: false
-    uuid: 03fb40c9-96a7-4142-9296-d72806c4c449
-    context_mapping:
-      node: '@node.node_route_context:node'
-    bundles: {  }
+conditions: {  }
 reactions:
   triplestore_index_reaction:
     id: triplestore_index_reaction

--- a/config/install/context.context.index_content_blazegraph.yml
+++ b/config/install/context.context.index_content_blazegraph.yml
@@ -17,9 +17,7 @@ conditions:
     uuid: 03fb40c9-96a7-4142-9296-d72806c4c449
     context_mapping:
       node: '@node.node_route_context:node'
-    bundles:
-      article: article
-      page: page
+    bundles: {  }
 reactions:
   triplestore_index_reaction:
     id: triplestore_index_reaction

--- a/config/install/context.context.index_media_blazegraph.yml
+++ b/config/install/context.context.index_media_blazegraph.yml
@@ -2,22 +2,14 @@ langcode: en
 status: true
 dependencies:
   module:
-    - media
     - triplestore_indexer
-label: 'All Media'
+label: Media
 name: index_media_blazegraph
 group: Indexing
 description: 'Index all media bundles Blazegraph'
 requireAllConditions: false
 disabled: false
-conditions:
-  'entity_bundle:media':
-    id: 'entity_bundle:media'
-    negate: false
-    uuid: 0e4b64bb-cf30-442c-b378-e4d501f80f56
-    context_mapping:
-      media: '@triplestore_indexer.media_route_context_provider:media'
-    bundles: {  }
+conditions: {  }
 reactions:
   triplestore_index_reaction:
     id: triplestore_index_reaction

--- a/config/install/context.context.index_media_blazegraph.yml
+++ b/config/install/context.context.index_media_blazegraph.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - triplestore_indexer
+label: 'All Media'
+name: index_media_blazegraph
+group: Indexing
+description: 'Index all media bundles Blazegraph'
+requireAllConditions: false
+disabled: false
+conditions:
+  'entity_bundle:media':
+    id: 'entity_bundle:media'
+    negate: false
+    uuid: 0e4b64bb-cf30-442c-b378-e4d501f80f56
+    context_mapping:
+      media: '@triplestore_indexer.media_route_context_provider:media'
+    bundles: {  }
+reactions:
+  triplestore_index_reaction:
+    id: triplestore_index_reaction
+    actions: index_media_to_triplestore_advancedqueue
+    saved: false
+weight: 0

--- a/config/install/context.context.index_taxonomy_terms_blazegraph.yml
+++ b/config/install/context.context.index_taxonomy_terms_blazegraph.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - triplestore_indexer
+label: 'Taxonomy Terms'
+name: index_taxonomy_terms_blazegraph
+group: Indexing
+description: 'Index taxonomy terms to Blazegraph.'
+requireAllConditions: false
+disabled: false
+conditions: {  }
+reactions:
+  triplestore_index_reaction:
+    id: triplestore_index_reaction
+    actions: index_taxonomy_term_to_triplestore_advancedqueue
+    saved: false
+weight: 0

--- a/config/schema/triplestore_indexer.schema.yml
+++ b/config/schema/triplestore_indexer.schema.yml
@@ -26,9 +26,3 @@ triplestore_indexer.settings:
     advancedqueue_id:
       type: string
       label: 'Advanced Queue ID'
-    content_type_to_index:
-      type: sequence
-      label: 'Content types to be indexed'
-      sequence:
-        type: string
-        label: 'Content type'

--- a/src/ContextProvider/MediaContextProvider.php
+++ b/src/ContextProvider/MediaContextProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\triplestore_indexer\ContextProvider;
+
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\media\MediaInterface;
+
+/**
+ * Sets the provided media as a context.
+ */
+class MediaContextProvider implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Media to provide in a context.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  protected $media;
+
+  /**
+   * Constructs a new MediaRouteContext.
+   *
+   * @var \Drupal\media\MediaInterface $media
+   *   The media to provide in a context.
+   */
+  public function __construct(MediaInterface $media) {
+    $this->media = $media;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $context = EntityContext::fromEntity($this->media);
+    return ['@triplestore_indexer.media_route_context_provider:media' => $context];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityType(\Drupal::entityTypeManager()->getDefinition('media'), $this->t('Media from URL'));
+    return ['@triplestore_indexer.media_route_context_provider:media' => $context];
+  }
+
+}

--- a/src/ContextProvider/MediaRouteContextProvider.php
+++ b/src/ContextProvider/MediaRouteContextProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\triplestore_indexer\ContextProvider;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\media\Entity\Media;
+
+/**
+ * Sets the current media as a context on media routes.
+ */
+class MediaRouteContextProvider implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The route match object.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new MediaRouteContextProvider.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match object.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $context_definition = EntityContextDefinition::fromEntityTypeId('media')->setLabel(NULL)->setRequired(FALSE);
+    $value = NULL;
+
+    $route_object = $this->routeMatch->getRouteObject();
+    if ($route_object) {
+      $route_contexts = $route_object->getOption('parameters');
+      if ($route_contexts && isset($route_contexts['media'])) {
+        $media = $this->routeMatch->getParameter('media');
+        if ($media) {
+          $value = $media;
+        }
+      }
+      elseif ($this->routeMatch->getRouteName() == 'entity.media.add_form') {
+        $media_type = $this->routeMatch->getParameter('media_type');
+        $value = Media::create(['bundle' => $media_type->id()]);
+      }
+    }
+
+    $cacheability = new CacheableMetadata();
+    $cacheability->setCacheContexts(['route']);
+
+    $context = new Context($context_definition, $value);
+    $context->addCacheableDependency($cacheability);
+    return ['media' => $context];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityType(\Drupal::entityTypeManager()->getDefinition('media'), $this->t('Media from URL'));
+    return ['media' => $context];
+  }
+
+}

--- a/src/ContextProvider/NodeContextProvider.php
+++ b/src/ContextProvider/NodeContextProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\triplestore_indexer\ContextProvider;
+
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+
+/**
+ * Sets the provided media as a context.
+ */
+class NodeContextProvider implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Node to provide in a context.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $node;
+
+  /**
+   * Constructs a new NodeContextProvider.
+   *
+   * @var \Drupal\node\NodeInterface $node
+   *   The node to provide in a context.
+   */
+  public function __construct(NodeInterface $node) {
+    $this->node = $node;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $context = EntityContext::fromEntity($this->node);
+    return ['@node.node_route_context:node' => $context];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityTypeId('node', $this->t('Node from entity hook'));
+    return ['@node.node_route_context:node' => $context];
+  }
+
+}

--- a/src/ContextProvider/TermContextProvider.php
+++ b/src/ContextProvider/TermContextProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\triplestore_indexer\ContextProvider;
+
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Sets the provided media as a context.
+ */
+class TermContextProvider implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Term to provide in a context.
+   *
+   * @var \Drupal\term\TermInterface
+   */
+  protected $term;
+
+  /**
+   * Constructs a new TermContextProvider.
+   *
+   * @var \Drupal\term\TermInterface $term
+   *   The term to provide in a context.
+   */
+  public function __construct(TermInterface $term) {
+    $this->term = $term;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $context = EntityContext::fromEntity($this->term);
+    return ['@triplestore_indexer.taxonomy_term_route_context_provider:taxonomy_term' => $context];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityTypeId('taxonomy_term', $this->t('Term from entity hook'));
+    return ['@triplestore_indexer.taxonomy_term_route_context_provider:taxonomy_term' => $context];
+  }
+
+}

--- a/src/ContextProvider/TermRouteContextProvider.php
+++ b/src/ContextProvider/TermRouteContextProvider.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\triplestore_indexer\ContextProvider;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Sets the current file as a context on file routes.
+ */
+class TermRouteContextProvider implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The route match object.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new TermRouteContextProvider.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match object.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $context_definition = EntityContextDefinition::fromEntityTypeId('taxonomy_term')->setLabel(NULL)->setRequired(FALSE);
+    $value = NULL;
+
+    $route_object = $this->routeMatch->getRouteObject();
+    if ($route_object) {
+      $route_contexts = $route_object->getOption('parameters');
+      if ($route_contexts && isset($route_contexts['taxonomy_term'])) {
+        $term = $this->routeMatch->getParameter('taxonomy_term');
+        if ($term) {
+          $value = $term;
+        }
+      }
+    }
+
+    $cacheability = new CacheableMetadata();
+    $cacheability->setCacheContexts(['route']);
+
+    $context = new Context($context_definition, $value);
+    $context->addCacheableDependency($cacheability);
+    return ['taxonomy_term' => $context];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityTypeId('taxonomy_term', $this->t('Term from URL'));
+    return ['taxonomy_term' => $context];
+  }
+
+}

--- a/src/Form/TripleStoreIndexerConfigForm.php
+++ b/src/Form/TripleStoreIndexerConfigForm.php
@@ -179,29 +179,6 @@ class TripleStoreIndexerConfigForm extends ConfigFormBase {
     ];
     $form['configuration']['#tree'] = TRUE;
 
-    $form['content-type'] = [
-      '#type' => 'details',
-      '#title' => $this
-        ->t('Condition: Node Bundle'),
-      '#group' => 'configuration',
-    ];
-
-    // Pull list of exsiting content types of the site.
-    $content_types = \Drupal::entityTypeManager()
-      ->getStorage('node_type')
-      ->loadMultiple();
-    $options_contentypes = [];
-    foreach ($content_types as $ct) {
-      $options_contentypes[$ct->id()] = $ct->label();
-    }
-
-    $form['content-type']['select-content-types'] = [
-      '#type' => 'checkboxes',
-      '#title' => t('Select which content type(s) to be indexed:'),
-      '#options' => $options_contentypes,
-      '#default_value' => ($config->get("content_type_to_index") !== NULL) ? array_keys(array_filter($config->get('content_type_to_index'))) : [],
-    ];
-
     $form['submit-save-config'] = [
       '#type' => 'submit',
       '#name' => "submit-save-server-config",
@@ -290,7 +267,6 @@ class TripleStoreIndexerConfigForm extends ConfigFormBase {
     }
 
     $configFactory->set('advancedqueue_id', $form_state->getValues()['advancedqueue_id']);
-    $configFactory->set('content_type_to_index', $form_state->getValues()['select-content-types']);
     $configFactory->save();
 
     parent::submitForm($form, $form_state);

--- a/src/Plugin/ContextReaction/DeleteReaction.php
+++ b/src/Plugin/ContextReaction/DeleteReaction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\triplestore_indexer\Plugin\ContextReaction;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\triplestore_indexer\ReactionBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Delete reaction.
+ *
+ * @ContextReaction(
+ *   id = "triplestore_delete_reaction",
+ *   label = @Translation("Triplestore Delete Reaction")
+ * )
+ */
+class DeleteReaction extends ReactionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Pre-configure a triplestore delete action.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')->getStorage('action'),
+      [
+        'delete_node_in_triplestore_advancedqueue',
+        'delete_media_in_triplestore_advancedqueue',
+        'delete_taxonomy_term_in_triplestore_advancedqueue',
+      ]
+    );
+  }
+
+}

--- a/src/Plugin/ContextReaction/IndexReaction.php
+++ b/src/Plugin/ContextReaction/IndexReaction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\triplestore_indexer\Plugin\ContextReaction;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\triplestore_indexer\ReactionBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Delete reaction.
+ *
+ * @ContextReaction(
+ *   id = "triplestore_index_reaction",
+ *   label = @Translation("Triplestore Index Reaction")
+ * )
+ */
+class IndexReaction extends ReactionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Pre-configure a triplestore index action.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')->getStorage('action'),
+      [
+        'index_node_to_triplestore_advancedqueue',
+        'index_media_to_triplestore_advancedqueue',
+        'index_taxonomy_term_to_triplestore_advancedqueue',
+      ]
+    );
+  }
+
+}

--- a/src/ReactionBase.php
+++ b/src/ReactionBase.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\triplestore_indexer;
+
+use Drupal\context\ContextReactionPluginBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Triplestore Actions context reaction base.
+ */
+class ReactionBase extends ContextReactionPluginBase {
+
+  /**
+   * Action storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $actionStorage;
+
+  /**
+   * Action IDs to display as options.
+   *
+   * @var array
+   */
+  protected $actionIds;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityStorageInterface $action_storage, $action_ids) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->actionStorage = $action_storage;
+    $this->actionIds = $action_ids;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Perform a pre-configured action.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(EntityInterface $entity = NULL) {
+    $config = $this->getConfiguration();
+    $entityType = $entity->getEntityTypeId();
+    $action_id = $config['actions'];
+    if (str_contains($action_id, $entityType)) {
+      $action = $this->actionStorage->load($action_id);
+      if ($action) {
+        $action->execute([$entity]);
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $actions = $this->actionStorage->loadMultiple($this->actionIds);
+    foreach ($actions as $action) {
+      $options[ucfirst($action->getType())][$action->id()] = $action->label();
+    }
+    $config = $this->getConfiguration();
+
+    $form['actions'] = [
+      '#title' => $this->t('Triplestore Actions'),
+      '#description' => $this->t('Pre-configured actions to execute.'),
+      '#type' => 'select',
+      '#options' => $options,
+      '#default_value' => $config['actions'] ?? '',
+      '#size' => 15,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfiguration(['actions' => $form_state->getValue('actions')]);
+  }
+
+}

--- a/src/TriplestoreContextManager.php
+++ b/src/TriplestoreContextManager.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\triplestore_indexer;
+
+use Drupal\Component\Plugin\Exception\ContextException;
+use Drupal\context\ContextInterface;
+use Drupal\context\ContextManager;
+use Drupal\Core\Condition\ConditionPluginCollection;
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+
+/**
+ * Provide additional bits to assist Contexts managing.
+ */
+class TriplestoreContextManager extends ContextManager {
+
+  /**
+   * Evaluate all context conditions.
+   *
+   * @param \Drupal\Core\Plugin\Context\Context[] $provided
+   *   Additional provided (core) contexts to apply to Conditions.
+   */
+  public function evaluateContexts(array $provided = []) {
+    $this->activeContexts = [];
+    if (!empty($provided)) {
+      $this->contexts = [];
+      $this->contextConditionsEvaluated = FALSE;
+    }
+    foreach ($this->getContexts() as $context) {
+      if ($this->evaluateContextConditions($context, $provided) && !$context->disabled()) {
+        $this->activeContexts[$context->id()] = $context;
+      }
+    }
+    $this->contextConditionsEvaluated = TRUE;
+  }
+
+  /**
+   * Evaluate a contexts conditions.
+   *
+   * @param \Drupal\context\ContextInterface $context
+   *   The context to evaluate conditions for.
+   * @param \Drupal\Core\Plugin\Context\Context[] $provided
+   *   Additional provided (core) contexts to apply to Conditions.
+   *
+   * @return bool
+   *   TRUE if conditions pass
+   */
+  public function evaluateContextConditions(ContextInterface $context, array $provided = []) {
+    $conditions = $context->getConditions();
+    if (!$this->applyContexts($conditions, $provided)) {
+      return FALSE;
+    }
+
+    $logic = $context->requiresAllConditions()
+      ? 'and'
+      : 'or';
+
+    if (!count($conditions)) {
+      $logic = 'and';
+    }
+
+    return $this->resolveConditions($conditions, $logic);
+  }
+
+  /**
+   * Apply context to all the context aware conditions in the collection.
+   *
+   * @param \Drupal\Core\Condition\ConditionPluginCollection $conditions
+   *   A collection of conditions to apply context to.
+   * @param \Drupal\Core\Plugin\Context\Context[] $provided
+   *   Additional provided (core) contexts to apply to Conditions.
+   *
+   * @return bool
+   *   TRUE if conditions pass
+   */
+  protected function applyContexts(ConditionPluginCollection &$conditions, array $provided = []) {
+    if (count($conditions) == 0) {
+      return TRUE;
+    }
+    $passed = FALSE;
+    foreach ($conditions as $condition) {
+      if ($condition instanceof ContextAwarePluginInterface) {
+        try {
+          if (empty($provided)) {
+            $contexts = $this->contextRepository->getRuntimeContexts(array_values($condition->getContextMapping()));
+          }
+          else {
+            $contexts = $provided;
+          }
+          $this->contextHandler->applyContextMapping($condition, $contexts);
+          $passed = TRUE;
+        }
+        catch (ContextException $e) {
+          continue;
+        }
+      }
+    }
+
+    return $passed;
+  }
+
+}

--- a/src/TriplestoreContextUtils.php
+++ b/src/TriplestoreContextUtils.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Drupal\triplestore_indexer;
+
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\Context\ContextHandlerInterface;
+use Drupal\Core\Plugin\Context\ContextRepositoryInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Theme\ThemeManagerInterface;
+use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+use Drupal\triplestore_indexer\ContextProvider\MediaContextProvider;
+use Drupal\triplestore_indexer\ContextProvider\NodeContextProvider;
+use Drupal\triplestore_indexer\ContextProvider\TermContextProvider;
+use Drupal\triplestore_indexer\TriplestoreContextManager;
+
+/**
+ * Utility functions for firing off context reactions.
+ */
+class TriplestoreContextUtils {
+  /**
+   * Context manager.
+   *
+   * @var \Drupal\triplestore_indexer\TriplestoreContextManager
+   */
+  protected $contextManager;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Plugin\Context\ContextRepositoryInterface $contextRepository
+   *   Context repository.
+   * @param \Drupal\Core\Plugin\Context\ContextHandlerInterface $contextHandler
+   *   Context handler.
+   * @param \Drupal\Core\Entity\EntityFormBuilderInterface $entityFormBuilder
+   *   Entity Form Builder.
+   * @param \Drupal\Core\Theme\ThemeManagerInterface $themeManager
+   *   Theme manager.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $currentRouteMatch
+   *   Route match.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entityTypeManager,
+    ContextRepositoryInterface $contextRepository,
+    ContextHandlerInterface $contextHandler,
+    EntityFormBuilderInterface $entityFormBuilder,
+    ThemeManagerInterface $themeManager,
+    RouteMatchInterface $currentRouteMatch
+  ) {
+    $this->contextManager = new TriplestoreContextManager(
+      $entityTypeManager,
+      $contextRepository,
+      $contextHandler,
+      $entityFormBuilder,
+      $themeManager,
+      $currentRouteMatch
+    );
+  }
+
+  /**
+   * Executes context reactions for a Node.
+   *
+   * @param string $reaction_type
+   *   Reaction type.
+   * @param \Drupal\node\NodeInterface $node
+   *   Node to evaluate contexts and pass to reaction.
+   */
+  public function executeNodeReactions($reaction_type, NodeInterface $node) {
+    $provider = new NodeContextProvider($node);
+    $provided = $provider->getRuntimeContexts([]);
+    $this->contextManager->evaluateContexts($provided);
+    foreach ($this->contextManager->getActiveReactions($reaction_type) as $reaction) {
+      $reaction->execute($node);
+    }
+  }
+
+  /**
+   * Executes context reactions for a Taxonomy Term.
+   *
+   * @param string $reaction_type
+   *   Reaction type.
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   Taxonomy term to evaluate contexts and pass to reaction.
+   */
+  public function executeTermReactions($reaction_type, TermInterface $term) {
+    $provider = new TermContextProvider($term);
+    $provided = $provider->getRuntimeContexts([]);
+    $this->contextManager->evaluateContexts($provided);
+    foreach ($this->contextManager->getActiveReactions($reaction_type) as $reaction) {
+      $reaction->execute($term);
+    }
+  }
+
+  /**
+   * Executes context reactions for a Media.
+   *
+   * @param string $reaction_type
+   *   Reaction type.
+   * @param \Drupal\media\MediaInterface $media
+   *   Media to evaluate contexts and pass to reaction.
+   */
+  public function executeMediaReactions($reaction_type, MediaInterface $media) {
+    $provider = new MediaContextProvider($media);
+    $provided = $provider->getRuntimeContexts([]);
+    $this->contextManager->evaluateContexts($provided);
+    foreach ($this->contextManager->getActiveReactions($reaction_type) as $reaction) {
+      $reaction->execute($media);
+    }
+  }
+
+}

--- a/triplestore_indexer.module
+++ b/triplestore_indexer.module
@@ -12,7 +12,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\TermInterface;
 use GuzzleHttp\Exception\ClientException;
 
 /**
@@ -43,13 +46,6 @@ function triplestore_indexer_theme() {
 }
 
 /**
- * Implements hook_entity_insert().
- */
-function triplestore_indexer_entity_insert(EntityInterface $entity) {
-  drupal_register_shutdown_function('execute_indexing_action', 'index_node_to_triplestore_advancedqueue', $entity);
-}
-
-/**
  * Implements hook_form_alter().
  */
 function triplestore_indexer_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -57,9 +53,14 @@ function triplestore_indexer_form_alter(&$form, FormStateInterface $form_state, 
   // Adding validator only to the content type that is indexed.
   if (preg_match('/^node_(.*)_delete_form$/', $form_id, $matches)) {
     $originalId = $matches[1];
-    $config = \Drupal::config('triplestore_indexer.settings');
-    $indexed_content = $config->get('content_type_to_index');
-    if (is_array($config->get('content_type_to_index')) && in_array($originalId, $indexed_content)) {
+    $entity_type_manager = \Drupal::service('entity_type.manager');
+    $content_types_list = $entity_type_manager->getStorage('node_type')->loadMultiple();
+
+    $content_types = [];
+    foreach ($content_types_list as $content_type) {
+      $content_types[] = $content_type->id();
+    }
+    if (in_array($originalId, $content_types)) {
       $form['#validate'][] = 'triplestore_indexer_node_delete_form_validate';
     }
   }
@@ -114,75 +115,75 @@ function triplestore_indexer_node_delete_form_validate($form, FormStateInterface
 }
 
 /**
- * Implements hook_entity_update().
+ * Implements hook_node_insert().
  */
-function triplestore_indexer_entity_update(EntityInterface $entity) {
-  drupal_register_shutdown_function('execute_indexing_action', 'index_node_to_triplestore_advancedqueue', $entity);
+function triplestore_indexer_node_insert(NodeInterface $node) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeNodeReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\IndexReaction', $node);
 }
 
 /**
- * Implements hook_entity_delete().
+ * Implements hook_node_update().
  */
-function triplestore_indexer_entity_predelete(EntityInterface $entity) {
-  // Both failed.
-  execute_indexing_action('delete_node_in_triplestore_advancedqueue', $entity);
+function triplestore_indexer_node_update(NodeInterface $node) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeNodeReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\IndexReaction', $node);
+}
 
-  // Delete content work, but delete indexed content in blazegraph works.
-  // drupal_register_shutdown_function('execute_indexing_action', 'delete_node_in_triplestore_advancedqueue', $entity);
+/**
+ * Implements hook_node_delete().
+ */
+function triplestore_indexer_node_delete(NodeInterface $node) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeNodeReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\DeleteReaction', $node);
 }
 
 /**
  * Implements hook_taxonomy_term_insert().
  */
-function triplestore_indexer_taxonomy_term_insert(EntityInterface $term) {
-  drupal_register_shutdown_function('execute_indexing_action', 'index_taxonomy_term_to_triplestore_advancedqueue', $term);
+function triplestore_indexer_taxonomy_term_insert(TermInterface $term) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeTermReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\IndexReaction', $term);
 }
 
 /**
  * Implements hook_taxonomy_term_update().
  */
-function triplestore_indexer_taxonomy_term_update(EntityInterface $term) {
-  drupal_register_shutdown_function('execute_indexing_action', 'index_taxonomy_term_to_triplestore_advancedqueue', $term);
+function triplestore_indexer_taxonomy_term_update(TermInterface $term) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeTermReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\IndexReaction', $term);
 }
 
 /**
  * Implements hook_taxonomy_term_delete().
  */
-function triplestore_indexer_taxonomy_term_predelete(EntityInterface $term) {
-  execute_indexing_action('delete_taxonomy_term_in_triplestore_advancedqueue', $term);
+function triplestore_indexer_taxonomy_term_delete(TermInterface $term) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeTermReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\DeleteReaction', $term);
 }
 
 /**
  * Implements hook_media_insert().
  */
-function triplestore_indexer_media_insert(EntityInterface $media) {
-  drupal_register_shutdown_function('execute_indexing_action', 'index_media_to_triplestore_advancedqueue', $media);
+function triplestore_indexer_media_insert(MediaInterface $media) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeMediaReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\IndexReaction', $media);
 }
 
 /**
  * Implements hook_media_update().
  */
-function triplestore_indexer_media_update(EntityInterface $media) {
-  drupal_register_shutdown_function('execute_indexing_action', 'index_media_to_triplestore_advancedqueue', $media);
+function triplestore_indexer_media_update(MediaInterface $media) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeMediaReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\IndexReaction', $media);
 }
 
 /**
  * Implements hook_media_delete().
  */
-function triplestore_indexer_media_predelete(EntityInterface $media) {
-  execute_indexing_action('delete_media_in_triplestore_advancedqueue', $media);
-}
-
-/**
- * Execute action with action name.
- */
-function execute_indexing_action(string $actionName, EntityInterface $entity) {
-  $action = \Drupal::entityTypeManager()
-    ->getStorage('action')
-    ->load($actionName);
-  if ($action) {
-    $action->execute([$entity]);
-  }
+function triplestore_indexer_media_delete(MediaInterface $media) {
+  $utils = \Drupal::service('triplestore_indexer.context_utils');
+  $utils->executeMediaReactions('\Drupal\triplestore_indexer\Plugin\ContextReaction\DeleteReaction', $media);
 }
 
 /**
@@ -279,13 +280,10 @@ function queue_process(EntityInterface $entity, $action) {
     return;
   }
 
-  // Get condition of which content type will be indexed.
-  $indexedContentTypes = (is_array($config->get('content_type_to_index'))) ? array_keys(array_filter($config->get('content_type_to_index'))) : [];
-
   switch ($action) {
     case 'insert':
     case 'update':
-      if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $indexedContentTypes) || $entity->getEntityTypeId() === 'taxonomy_term' || $entity->getEntityTypeId() === 'media') {
+      if ($entity->getEntityTypeId() === 'node' || $entity->getEntityTypeId() === 'taxonomy_term' || $entity->getEntityTypeId() === 'media') {
         // Create a job and add to Advanced Queue.
         $payload = [
           'nid' => $entity->id(),
@@ -299,7 +297,7 @@ function queue_process(EntityInterface $entity, $action) {
 
     case 'delete':
     case '[Update] delete if exist':
-      if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), $indexedContentTypes)) {
+      if ($entity->getEntityTypeId() === 'node') {
         // Get @id of other components associated with node.
         $payload = [
           'nid' => $entity->id(),

--- a/triplestore_indexer.services.yml
+++ b/triplestore_indexer.services.yml
@@ -5,3 +5,16 @@ services:
   triplestore_indexer.indexing:
     class: Drupal\triplestore_indexer\IndexingService
     arguments: []
+  triplestore_indexer.context_utils:
+    class: Drupal\triplestore_indexer\TriplestoreContextUtils
+    arguments: ['@entity_type.manager', '@context.repository', '@context.handler', '@entity.form_builder', '@theme.manager', '@current_route_match']
+  triplestore_indexer.taxonomy_term_route_context_provider:
+    class: Drupal\triplestore_indexer\ContextProvider\TermRouteContextProvider
+    arguments: ['@current_route_match']
+    tags:
+      - { name: 'context_provider' }
+  triplestore_indexer.media_route_context_provider:
+    class: Drupal\triplestore_indexer\ContextProvider\MediaRouteContextProvider
+    arguments: ['@current_route_match']
+    tags:
+      - { name: 'context_provider' }


### PR DESCRIPTION
# Summary
- Replaced media, node, and taxonomy term hooks to check Contexts and then run reaction if context conditions are met
- Added IndexReaction and DeleteReaction to add the existing Triplestore Actions with the Context Reaction
- Added a Context Utility service to assist the context executions